### PR TITLE
2 ignore files when scanning for components

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ bundle exec rake[components]
 ## Contributing
 
 1. Fork it ( https://github.com/dugancathal/transdeps/fork )
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create a new Pull Request
+1. Create your feature branch (`git checkout -b my-new-feature`)
+1. Install gems (`gem install bundler && bundle`)
+1. Run tests (`rspec`)
+1. Commit your changes (`git commit -am 'Add some feature'`)
+1. Push to the branch (`git push origin my-new-feature`)
+1. Create a new Pull Request

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Or install it yourself as:
 
 ## Usage
 
+### Using `rake`
+
 Add this line to application's Rakefile:
 
 ```ruby
@@ -39,6 +41,25 @@ first argument would be a relative path. Something like:
 
 ```bash
 bundle exec rake[components]
+```
+
+### Using `rspec`
+
+Add this spec:
+
+```ruby
+require "transdeps/cli"
+
+RSpec.describe "Component" do
+  it "uses the same version of dependencies as the ones in the container application" do
+    results = Transdeps::Cli.new("components").run
+    expect(results).to be_empty, failure_message(results)
+  end
+
+  def failure_message(results)
+    (["❌  Dependency inconsistencies found:"] + results).join("\n")
+  end
+end
 ```
 
 ## Contributing

--- a/lib/transdeps/reconciler.rb
+++ b/lib/transdeps/reconciler.rb
@@ -9,16 +9,28 @@ module Transdeps
 
     def call(component_dir, project_dir)
       project_specs = specs_for(project_dir)
-      all_component_specs = component_dir.children.map { |dir| specs_for(dir) }
-      all_component_specs.flat_map do |component_specs|
-        project_specs - component_specs
-      end.compact
+      all_component_specs = all_component_specs(component_dir)
+
+      spec_differences(project_specs, all_component_specs)
     end
 
     private
 
     def specs_for(dir)
       factory.call(dir)
+    end
+
+    def all_component_specs(component_dir)
+      component_dir
+        .children
+        .select { |filename| File.directory?(filename) }
+        .map { |dir| specs_for(dir) }
+    end
+
+    def spec_differences(project_specs, all_component_specs)
+      all_component_specs.flat_map do |component_specs|
+        project_specs - component_specs
+      end.compact
     end
   end
 end

--- a/spec/transdeps/reconciler_spec.rb
+++ b/spec/transdeps/reconciler_spec.rb
@@ -25,5 +25,15 @@ module Transdeps
 
       expect(result).to eq [Inconsistency.new(ten_dot_oh, ten_dot_one)]
     end
+
+    it 'ignores files in components directory' do
+      factory = SpecListFactory.new
+      rec = Reconciler.new(factory)
+      component_dir = double(Dir, children: [DUMMY_APP_PATH + 'components/a-file'])
+
+      result = rec.call(component_dir, DUMMY_APP_PATH)
+
+      expect(result).to be_empty
+    end
   end
 end


### PR DESCRIPTION
Solves #2 

I also added documentation on how to use this gem from a spec. This way, a CI pipeline could also check for dependency inconsistencies.