### PR TITLE
Add support for uncommon gem names

### DIFF
--- a/lib/transdeps/specification.rb
+++ b/lib/transdeps/specification.rb
@@ -1,7 +1,7 @@
 module Transdeps
   class Specification < Struct.new(:name, :version, :project_path)
     def self.from_lock(lock, path='')
-      match = lock.match(/^(?<name>[\w\-]+) \((?<version>.*)\)/)
+      match = lock.match(/^(?<name>[^\s]+) \((?<version>.*)\)/)
       new(match[:name], match[:version], path)
     end
 

--- a/spec/transdeps/specification_spec.rb
+++ b/spec/transdeps/specification_spec.rb
@@ -23,6 +23,13 @@ describe Transdeps::Specification do
       expect(spec.name).to eq 'rake_lib'
       expect(spec.version).to eq '10.0.0'
     end
+
+    it 'works for names with dots' do
+      lock = 'http_parser.rb (0.6.0)'
+      spec = Transdeps::Specification.from_lock(lock)
+      expect(spec.name).to eq 'http_parser.rb'
+      expect(spec.version).to eq '0.6.0'
+    end
   end
 
   describe 'match-y-ness' do


### PR DESCRIPTION
This branch supports gems that contain characters that are neither word characters (`\w`) nor dashes (`-`).

An example of such a gem is the [http_parser.rb](https://rubygems.org/gems/http_parser.rb/versions/0.6.0) gem.