### PR TITLE
upgrades bundler and rake to fix rake deprecation warning on Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 rvm:
-  - 2.2.4
-before_install: gem install bundler -v 1.17.3
+  - 2.7.2
+before_install: gem install bundler -v 2.1.4

--- a/transdeps.gemspec
+++ b/transdeps.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 2.1"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
I'm planning to make another bigger PR, but I had to upgrade bundler and rake to be able to run the tests. I think it makes sense to merge this PR first, since it's independent to the changes I'm planning to make